### PR TITLE
Fix: Only git start lines if found in message

### DIFF
--- a/gjira/gjira.py
+++ b/gjira/gjira.py
@@ -92,8 +92,11 @@ def update_commit_message(filename: str, content: str) -> list:
         else:
             content = f"\n{content}\n"
 
+        if pos > 0: # append the start line if it was found above
+            content = f"{content}{GIT_START_LINES}"
+
         # add fmt to the corresponding position and read any unread line
-        lines = lines + [content] + [GIT_START_LINES] + fd.readlines()
+        lines = lines + [content] + fd.readlines()
 
         # Write lines back to file
         fd.seek(0)


### PR DESCRIPTION
When appending the Jira info to the commit message, only add back in the
GIT_START_LINES if the lines was found during the enumeration. This
means it will only be printed if it was originally in the commit message.
This will fix a bug where certain git tools such as SourceTree apply the
pre-commit hook after the user has written the message, and as a result
printing the start line out would append it to the final commit, despite
the line starting with '#'.